### PR TITLE
Feature/airlines migration

### DIFF
--- a/prisma/migrations/20240318101146_init/migration.sql
+++ b/prisma/migrations/20240318101146_init/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - Added the required column `seviceType` to the `Airline` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "AirlineSeviceType" AS ENUM ('lcc', 'fsc', 'hsc', 'else');
+
+-- CreateEnum
+CREATE TYPE "AirType" AS ENUM ('airports', 'airlines');
+
+-- AlterTable
+ALTER TABLE "Airline" ADD COLUMN     "seviceType" "AirlineSeviceType" NOT NULL;
+
+-- CreateTable
+CREATE TABLE "AirUpdateHistory" (
+    "id" SERIAL NOT NULL,
+    "airType" "AirType" NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AirUpdateHistory_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("POSTGRES_PRISMA_URL")
+  url      = env("POSTGRES_URL")
 }
 
 // Model 定義

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,3 +103,14 @@ model Flight {
   arrivalDate          String
   price                Int        @default(0)
 }
+
+
+enum AirType { 
+  airports
+  airlines
+}
+model AirUpdateHistory {
+  id                   Int        @id @default(autoincrement())
+  airType              AirType
+  updatedAt            DateTime
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,12 +39,19 @@ model User {
     favoriteAirlines   FavoriteAirline[]
 }
 
+enum AirlineSeviceType {
+  lcc
+  fsc
+  hsc
+  else
+}
 model Airline {
     id                 Int        @id @default(autoincrement())
     title              String 
     detailTitle        String 
     iata               String
     icao               String
+    seviceType         AirlineSeviceType
     flight             Flight[]
     favoriteAirlines   FavoriteAirline[]
 }


### PR DESCRIPTION
https://www.notion.so/migration-update-Airline-Column-49b849fb553d4aa799ec1cd061fb12a0?pvs=4

### 航空のタイプカラムー追加

### 新規テーブル追加
- 空港、航空の情報の更新した日を保存するテーブル追加